### PR TITLE
Support arm64 (Apple Silicon)

### DIFF
--- a/OpenSteamAPI/src/Makefile
+++ b/OpenSteamAPI/src/Makefile
@@ -7,6 +7,10 @@ ifeq ($(UNAME_M), x86_64)
 	BUILD_ARCH := 64
 endif
 
+ifeq ($(UNAME_M), arm64)
+	BUILD_ARCH := 64
+endif
+
 FLAGS = -m$(BUILD_ARCH) -fPIC -O2 -c -I../../OpenSteamworks
 
 LIBNAME = ../lib/Linux$(BUILD_ARCH)/OpenSteamAPI.a


### PR DESCRIPTION
Treating the arm64 architecture as 64-bit appears to be enough to compile successfully on an M1 Pro, and likely the rest of the current Apple Silicon-based chips.