### PR TITLE
fix strncat buffer overflow warning

### DIFF
--- a/OpenSteamAPI/src/Interface_OSW.cpp
+++ b/OpenSteamAPI/src/Interface_OSW.cpp
@@ -87,7 +87,8 @@ void CSteamAPILoader::TryGetSteamDir()
 
 	if (GetApplicationSupportPath(m_szSteamPath, sizeof(m_szSteamPath)))
 	{
-		strncat(m_szSteamPath, "/Steam/Steam.AppBundle/Steam/Contents/MacOS/", sizeof(m_szSteamPath));
+		strncat(m_szSteamPath, "/Steam/Steam.AppBundle/Steam/Contents/MacOS/",
+			sizeof(m_szSteamPath) - strlen(m_szSteamPath) - 1);
 		bFallback = false;
 	}
 
@@ -100,13 +101,14 @@ void CSteamAPILoader::TryGetSteamDir()
 
 	char* szHome = getpwuid(getuid())->pw_dir;
 
-	strncat(m_szSteamPath, szHome, sizeof(m_szSteamPath));
+	strncat(m_szSteamPath, szHome, sizeof(m_szSteamPath) - strlen(m_szSteamPath) - 1);
 
 #ifdef __LP64__
-	strncat(m_szSteamPath, "/.steam/sdk64/", sizeof(m_szSteamPath));
+	const char* szSDKPath = "/.steam/sdk64/";
 #else
-	strncat(m_szSteamPath, "/.steam/sdk32/", sizeof(m_szSteamPath));
+	const char* szSDKPath = "/.steam/sdk32/";
 #endif
+	strncat(m_szSteamPath, szSDKPath, sizeof(m_szSteamPath) - strlen(m_szSteamPath) - 1);
 
 	struct stat info;
 	if (stat(m_szSteamPath, &info) == 0)


### PR DESCRIPTION
- limits.h.0p: PATH_MAX ends with NULL
- strncat APPENDS to current string end in buffer, the size limit does not account for the trailing NULL

Short of using a friendlier function, we must first determine where the current string ends to calculate available free length in buffer.

https://stackoverflow.com/a/6904422

---

Before on Linux 64-bit, following default compilation instructions:
```
Interface_OSW.cpp: In member function ‘void CSteamAPILoader::TryGetSteamDir()’:
Interface_OSW.cpp:103:16: warning: ‘char* strncat(char*, const char*, size_t)’ specified bound 4096 equals destination size [-Wstringop-overflow=]
  103 |         strncat(m_szSteamPath, szHome, sizeof(m_szSteamPath));
      |         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Quick test after compilation: OK.